### PR TITLE
Migrate from Coveralls to Code Climate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,16 +16,47 @@ jobs:
           tox-env: py38
         - python-version: '3.9'
           tox-env: py39
-        - python-version: '2.7'
-          tox-env: coveralls
-        - python-version: '2.7'
-          tox-env: flake8
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install tox
+    - name: Install cc-test-reporter
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+    - run: pip install coverage tox
+    - run: ./cc-test-reporter before-build
     - run: tox -e ${{ matrix.tox-env }}
+    - name: Format coverage
+      run: |
+        coverage xml
+        ./cc-test-reporter format-coverage --input-type coverage.py --output 'coverage.${{ matrix.python-version }}.xml'
+    - uses: actions/upload-artifact@v2
+      with:
+        name: coverages
+        path: coverage.${{ matrix.python-version }}.xml
+  upload-coverage:
+    runs-on: ubuntu-20.04
+    needs: test
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: coverages
+    - name: Install cc-test-reporter
+      run: |
+        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+        chmod +x ./cc-test-reporter
+    - name: Upload coverage
+      run: ./cc-test-reporter sum-coverage --output - coverage.*.xml | ./cc-test-reporter upload-coverage --debug --input -
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - run: pip install tox
+    - run: tox -e flake8

--- a/tox.ini
+++ b/tox.ini
@@ -2,18 +2,10 @@
 envlist = py{27,37,38,39}, flake8
 
 [testenv]
-commands = {envpython} -m unittest discover -v tests
-
-[testenv:coveralls]
-basepython = python2.7
-passenv =
-    COVERALLS_REPO_TOKEN
-deps = coveralls
-commands =
-    coverage run --source=backquotes -m unittest discover tests
-    coveralls
+deps = coverage
+commands = {envpython} -m coverage run --source=backquotes -m unittest discover -v tests
 
 [testenv:flake8]
-basepython = python2.7
+basepython = python3.9
 deps = flake8
 commands = flake8 backquotes.py setup.py


### PR DESCRIPTION
I decided to migrate from Coveralls to Code Climate because:

- `coveralls` package has dropped support for Python 2
     - TheKevJames/coveralls-python#242
- Official GitHub Action hasn't support Python yet
    - coverallsapp/github-action#4
- This project is using Code Climate for static analysis
